### PR TITLE
Show track covers and load Supabase tracks

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     .muted{ color:var(--muted); }
     .btn{ background:var(--green); color:#051405; border-radius:999px; padding:.55rem 1rem; font-weight:700; }
     .btn-ghost{ background:rgba(255,255,255,.08); border-radius:999px; padding:.45rem .75rem; }
-    .row{ display:grid; grid-template-columns: 1.5rem 1fr auto auto 2rem; gap:1rem; align-items:center; }
+    .row{ display:grid; grid-template-columns: 1.5rem 3rem 1fr auto auto 2rem; gap:1rem; align-items:center; }
     .row:hover{ background:rgba(255,255,255,.06); }
     .queue{ position:fixed; right:0; top:0; bottom:88px; width:360px; max-width:95vw; background:#0f1012; border-left:1px solid rgba(255,255,255,.1); transform:translateX(100%); transition:.25s transform; z-index:40; }
     .queue.open{ transform:translateX(0); }
@@ -31,7 +31,7 @@
     .mobile-hide{ display:block; }
     @media (max-width: 768px){
       .mobile-hide{ display:none; }
-      .row{ grid-template-columns: 1.5rem 1fr auto 2rem; }
+      .row{ grid-template-columns: 1.5rem 3rem 1fr auto 2rem; }
     }
     .player{ position:fixed; left:0; right:0; bottom:0; background:#0f1012; border-top:1px solid rgba(255,255,255,.1); padding:.6rem .8rem; display:grid; grid-template-columns: 1fr auto 1fr; gap:.5rem; align-items:center; z-index:45; }
     .range{ appearance:none; width:100%; height:4px; background:#2a2d33; border-radius:999px; }
@@ -171,7 +171,13 @@
     async function fetchTracks(albumId){
       if(state.tracksByAlbum.has(albumId)) return state.tracksByAlbum.get(albumId);
       const {data,error}=await sb.from('tracks').select('*').eq('album_id',albumId).order('sort_index',{ascending:true});
-      const rows=(data||[]).map(t=>({...t, audio_url: normalizeDropbox(t.audio_url||'')}));
+      const album=state.albums.find(a=>a.id===albumId);
+      const albumCover=album?.cover_url||'';
+      const rows=(data||[]).map(t=>({
+        ...t,
+        audio_url: normalizeDropbox(t.audio_url||''),
+        cover_url: normalizeDropbox(t.cover_url||albumCover)
+      }));
       if(!error){ state.tracksByAlbum.set(albumId, rows); return rows; } return [];
     }
     async function fetchPopular(limit=5){ if(!state.albums.length) return []; const tracks=await fetchTracks(state.albums[0].id); return tracks.slice(0,limit); }
@@ -201,6 +207,7 @@
         const row=document.createElement('div'); row.className='row px-2 rounded cursor-pointer';
         row.innerHTML=`
           <div class="text-sm muted">${i+1}</div>
+          <img src="${t.cover_url}" class="w-10 h-10 object-cover rounded" referrerpolicy="no-referrer" onerror="this.style.display='none'"/>
           <div class="min-w-0">
             <div class="truncate font-semibold">${t.title}</div>
             <div class="muted text-sm">${t.explicit?'<span class="explicit">E</span>':''}</div>


### PR DESCRIPTION
## Summary
- Include album cover URLs when fetching tracks from Supabase
- Display cover art for popular tracks and adjust list layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67c5800808330b63ccf5ba96152a1